### PR TITLE
feat(parser): integrate Druid SQL parser

### DIFF
--- a/backend/src/main/java/com/lineage/core/dialect/DbTypeResolver.java
+++ b/backend/src/main/java/com/lineage/core/dialect/DbTypeResolver.java
@@ -1,0 +1,74 @@
+package com.lineage.core.dialect;
+
+import com.alibaba.druid.DbType;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 数据库方言解析器
+ * 
+ * 根据数据库类型字符串解析为 Druid DbType
+ */
+@Component
+public class DbTypeResolver {
+
+    private static final Map<String, DbType> DB_TYPE_MAP = new HashMap<>();
+
+    static {
+        DB_TYPE_MAP.put("mysql", DbType.mysql);
+        DB_TYPE_MAP.put("hive", DbType.hive);
+        DB_TYPE_MAP.put("postgresql", DbType.postgresql);
+        DB_TYPE_MAP.put("oracle", DbType.oracle);
+        DB_TYPE_MAP.put("sqlserver", DbType.sqlserver);
+    }
+
+    /**
+     * 解析数据库类型字符串
+     *
+     * @param dbTypeStr 数据库类型字符串（不区分大小写）
+     * @return Druid DbType
+     * @throws IllegalArgumentException 不支持的数据库类型
+     */
+    public DbType resolve(String dbTypeStr) {
+        if (StringUtils.isBlank(dbTypeStr)) {
+            throw new IllegalArgumentException("Database type cannot be blank");
+        }
+
+        String normalizedType = dbTypeStr.trim().toLowerCase();
+        DbType dbType = DB_TYPE_MAP.get(normalizedType);
+
+        if (dbType == null) {
+            throw new IllegalArgumentException(
+                String.format("Unsupported database type: %s. Supported types: %s", 
+                    dbTypeStr, DB_TYPE_MAP.keySet())
+            );
+        }
+
+        return dbType;
+    }
+
+    /**
+     * 检查是否支持指定的数据库类型
+     *
+     * @param dbTypeStr 数据库类型字符串
+     * @return true if supported
+     */
+    public boolean isSupported(String dbTypeStr) {
+        if (StringUtils.isBlank(dbTypeStr)) {
+            return false;
+        }
+        return DB_TYPE_MAP.containsKey(dbTypeStr.trim().toLowerCase());
+    }
+
+    /**
+     * 获取所有支持的数据库类型
+     *
+     * @return 支持的数据库类型列表
+     */
+    public Map<String, DbType> getSupportedTypes() {
+        return new HashMap<>(DB_TYPE_MAP);
+    }
+}

--- a/backend/src/main/java/com/lineage/service/DruidParserService.java
+++ b/backend/src/main/java/com/lineage/service/DruidParserService.java
@@ -1,0 +1,108 @@
+package com.lineage.service;
+
+import com.alibaba.druid.DbType;
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.parser.SQLParserUtils;
+import com.alibaba.druid.sql.parser.SQLStatementParser;
+import com.lineage.core.dialect.DbTypeResolver;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Druid SQL 解析服务
+ * 
+ * 负责将 SQL 字符串解析为 Druid AST（抽象语法树）
+ */
+@Slf4j
+@Service
+public class DruidParserService {
+
+    @Autowired
+    private DbTypeResolver dbTypeResolver;
+
+    /**
+     * 解析 SQL 为 AST（抽象语法树）
+     *
+     * @param sql    SQL 语句
+     * @param dbType 数据库类型字符串
+     * @return SQLStatement 列表
+     * @throws IllegalArgumentException SQL 为空或解析失败
+     */
+    public List<SQLStatement> parseSQL(String sql, String dbType) {
+        validateInput(sql, dbType);
+
+        DbType resolvedDbType = dbTypeResolver.resolve(dbType);
+        log.debug("Parsing SQL with database type: {}", resolvedDbType);
+
+        try {
+            List<SQLStatement> statements = SQLUtils.parseStatements(sql, resolvedDbType);
+            log.info("Successfully parsed {} SQL statement(s)", statements.size());
+            return statements;
+        } catch (Exception e) {
+            log.error("Failed to parse SQL: {}", sql, e);
+            throw new IllegalArgumentException("SQL parsing failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 解析单条 SQL 语句
+     *
+     * @param sql    SQL 语句
+     * @param dbType 数据库类型字符串
+     * @return 第一个 SQLStatement
+     * @throws IllegalArgumentException SQL 为空或解析失败
+     */
+    public SQLStatement parseSingleSQL(String sql, String dbType) {
+        List<SQLStatement> statements = parseSQL(sql, dbType);
+        
+        if (statements.isEmpty()) {
+            throw new IllegalArgumentException("No SQL statement found");
+        }
+
+        if (statements.size() > 1) {
+            log.warn("Multiple SQL statements found, returning first one");
+        }
+
+        return statements.get(0);
+    }
+
+    /**
+     * 格式化 SQL（美化输出）
+     *
+     * @param sql    原始 SQL
+     * @param dbType 数据库类型字符串
+     * @return 格式化后的 SQL
+     */
+    public String formatSQL(String sql, String dbType) {
+        validateInput(sql, dbType);
+
+        // 先验证SQL是否可解析
+        parseSQL(sql, dbType);
+
+        DbType resolvedDbType = dbTypeResolver.resolve(dbType);
+        
+        try {
+            return SQLUtils.format(sql, resolvedDbType);
+        } catch (Exception e) {
+            log.error("Failed to format SQL: {}", sql, e);
+            throw new IllegalArgumentException("SQL formatting failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 验证输入参数
+     */
+    private void validateInput(String sql, String dbType) {
+        if (StringUtils.isBlank(sql)) {
+            throw new IllegalArgumentException("SQL cannot be blank");
+        }
+        if (StringUtils.isBlank(dbType)) {
+            throw new IllegalArgumentException("Database type cannot be blank");
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -152,9 +152,6 @@ spring:
   config:
     activate:
       on-profile: dev
-
-# 开发环境数据源（H2）
-spring:
   datasource:
     url: jdbc:h2:file:./data/lineage_dev;MODE=MySQL;DATABASE_TO_LOWER=TRUE
     initialization-mode: always
@@ -175,15 +172,11 @@ spring:
   config:
     activate:
       on-profile: prod
-
-# 生产环境数据源（MySQL）
-spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/lineage_db?useUnicode=true&characterEncoding=utf8&serverTimezone=GMT%2B8&useSSL=false&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:}
-    
     hikari:
       minimum-idle: 10
       maximum-pool-size: 50

--- a/backend/src/test/java/com/lineage/core/dialect/DbTypeResolverTest.java
+++ b/backend/src/test/java/com/lineage/core/dialect/DbTypeResolverTest.java
@@ -1,0 +1,134 @@
+package com.lineage.core.dialect;
+
+import com.alibaba.druid.DbType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DbTypeResolverTest {
+
+    private DbTypeResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new DbTypeResolver();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "mysql, mysql",
+        "MYSQL, mysql",
+        "MySQL, mysql",
+        "hive, hive",
+        "HIVE, hive",
+        "postgresql, postgresql",
+        "PostgreSQL, postgresql",
+        "  mysql  , mysql"
+    })
+    void testResolveWithValidTypes(String input, String expectedType) {
+        DbType result = resolver.resolve(input);
+        assertNotNull(result);
+        assertEquals(expectedType, result.name().toLowerCase());
+    }
+
+    @Test
+    void testResolveMySql() {
+        DbType result = resolver.resolve("mysql");
+        assertEquals(DbType.mysql, result);
+    }
+
+    @Test
+    void testResolveHive() {
+        DbType result = resolver.resolve("hive");
+        assertEquals(DbType.hive, result);
+    }
+
+    @Test
+    void testResolvePostgreSQL() {
+        DbType result = resolver.resolve("postgresql");
+        assertEquals(DbType.postgresql, result);
+    }
+
+    @Test
+    void testResolveCaseInsensitive() {
+        assertEquals(DbType.mysql, resolver.resolve("MySQL"));
+        assertEquals(DbType.hive, resolver.resolve("HIVE"));
+        assertEquals(DbType.postgresql, resolver.resolve("PostgreSQL"));
+    }
+
+    @Test
+    void testResolveWithWhitespace() {
+        assertEquals(DbType.mysql, resolver.resolve("  mysql  "));
+        assertEquals(DbType.hive, resolver.resolve("\thive\t"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "\t", "\n"})
+    void testResolveWithBlankInput(String input) {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> resolver.resolve(input)
+        );
+        assertEquals("Database type cannot be blank", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"unknown", "db2", "informix", "invalid_type"})
+    void testResolveWithUnsupportedType(String unsupportedType) {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> resolver.resolve(unsupportedType)
+        );
+        assertTrue(exception.getMessage().contains("Unsupported database type"));
+        assertTrue(exception.getMessage().contains(unsupportedType));
+    }
+
+    @Test
+    void testIsSupported() {
+        assertTrue(resolver.isSupported("mysql"));
+        assertTrue(resolver.isSupported("MYSQL"));
+        assertTrue(resolver.isSupported("hive"));
+        assertTrue(resolver.isSupported("postgresql"));
+        
+        assertFalse(resolver.isSupported("spark"));
+        assertFalse(resolver.isSupported("unknown"));
+        assertFalse(resolver.isSupported("db2"));
+        assertFalse(resolver.isSupported(""));
+        assertFalse(resolver.isSupported(null));
+        assertFalse(resolver.isSupported("  "));
+    }
+
+    @Test
+    void testGetSupportedTypes() {
+        Map<String, DbType> supportedTypes = resolver.getSupportedTypes();
+        
+        assertNotNull(supportedTypes);
+        assertTrue(supportedTypes.size() >= 3);
+        assertTrue(supportedTypes.containsKey("mysql"));
+        assertTrue(supportedTypes.containsKey("hive"));
+        assertTrue(supportedTypes.containsKey("postgresql"));
+        
+        assertEquals(DbType.mysql, supportedTypes.get("mysql"));
+        assertEquals(DbType.hive, supportedTypes.get("hive"));
+        assertEquals(DbType.postgresql, supportedTypes.get("postgresql"));
+    }
+
+    @Test
+    void testGetSupportedTypesReturnsNewMap() {
+        Map<String, DbType> map1 = resolver.getSupportedTypes();
+        Map<String, DbType> map2 = resolver.getSupportedTypes();
+        
+        assertNotSame(map1, map2);
+        
+        map1.clear();
+        assertFalse(resolver.getSupportedTypes().isEmpty());
+    }
+}

--- a/backend/src/test/java/com/lineage/service/DruidParserServiceTest.java
+++ b/backend/src/test/java/com/lineage/service/DruidParserServiceTest.java
@@ -1,0 +1,219 @@
+package com.lineage.service;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import com.lineage.core.dialect.DbTypeResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class DruidParserServiceTest {
+
+    @Autowired
+    private DruidParserService parserService;
+
+    @Autowired
+    private DbTypeResolver dbTypeResolver;
+
+    @Test
+    void testParseSimpleMySQLSelect() {
+        String sql = "SELECT id, name FROM users WHERE age > 18";
+        List<SQLStatement> statements = parserService.parseSQL(sql, "mysql");
+
+        assertNotNull(statements);
+        assertEquals(1, statements.size());
+        assertTrue(statements.get(0) instanceof SQLSelectStatement);
+    }
+
+    @Test
+    void testParseSimpleHiveSelect() {
+        String sql = "SELECT * FROM hive_table WHERE dt = '2024-01-01'";
+        List<SQLStatement> statements = parserService.parseSQL(sql, "hive");
+
+        assertNotNull(statements);
+        assertEquals(1, statements.size());
+        assertTrue(statements.get(0) instanceof SQLSelectStatement);
+    }
+
+    @Test
+    void testParseSimplePostgreSQLSelect() {
+        String sql = "SELECT user_id, COUNT(*) as cnt FROM events GROUP BY user_id";
+        List<SQLStatement> statements = parserService.parseSQL(sql, "postgresql");
+
+        assertNotNull(statements);
+        assertEquals(1, statements.size());
+        assertTrue(statements.get(0) instanceof SQLSelectStatement);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "mysql, SELECT 1",
+        "hive, SELECT * FROM table1",
+        "postgresql, SELECT id FROM pg_table"
+    })
+    void testParseWithDifferentDialects(String dbType, String sql) {
+        List<SQLStatement> statements = parserService.parseSQL(sql, dbType);
+        
+        assertNotNull(statements);
+        assertFalse(statements.isEmpty());
+        assertTrue(statements.get(0) instanceof SQLSelectStatement);
+    }
+
+    @Test
+    void testParseMultipleStatements() {
+        String sql = "SELECT * FROM t1; SELECT * FROM t2; SELECT * FROM t3";
+        List<SQLStatement> statements = parserService.parseSQL(sql, "mysql");
+
+        assertNotNull(statements);
+        assertEquals(3, statements.size());
+        statements.forEach(stmt -> assertTrue(stmt instanceof SQLSelectStatement));
+    }
+
+    @Test
+    void testParseSingleSQL() {
+        String sql = "SELECT id, name FROM users";
+        SQLStatement statement = parserService.parseSingleSQL(sql, "mysql");
+
+        assertNotNull(statement);
+        assertTrue(statement instanceof SQLSelectStatement);
+    }
+
+    @Test
+    void testParseSingleSQLWithMultipleStatements() {
+        String sql = "SELECT * FROM t1; SELECT * FROM t2";
+        SQLStatement statement = parserService.parseSingleSQL(sql, "mysql");
+
+        assertNotNull(statement);
+        assertTrue(statement instanceof SQLSelectStatement);
+    }
+
+    @Test
+    void testParseSingleSQLWithNoStatement() {
+        String sql = "";
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            parserService.parseSingleSQL(sql, "mysql");
+        });
+    }
+
+    @Test
+    void testParseComplexSQL() {
+        String sql = "SELECT u.id, u.name, o.order_id " +
+                    "FROM users u " +
+                    "LEFT JOIN orders o ON u.id = o.user_id " +
+                    "WHERE u.age > 18 " +
+                    "ORDER BY u.name";
+        
+        List<SQLStatement> statements = parserService.parseSQL(sql, "mysql");
+        
+        assertNotNull(statements);
+        assertEquals(1, statements.size());
+    }
+
+    @Test
+    void testParseWithSubquery() {
+        String sql = "SELECT * FROM (SELECT id, name FROM users WHERE age > 18) t";
+        List<SQLStatement> statements = parserService.parseSQL(sql, "mysql");
+
+        assertNotNull(statements);
+        assertEquals(1, statements.size());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "\t", "\n"})
+    void testParseWithBlankSQL(String sql) {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> parserService.parseSQL(sql, "mysql")
+        );
+        assertEquals("SQL cannot be blank", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "\t"})
+    void testParseWithBlankDbType(String dbType) {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> parserService.parseSQL("SELECT 1", dbType)
+        );
+        assertEquals("Database type cannot be blank", exception.getMessage());
+    }
+
+    @Test
+    void testParseWithUnsupportedDbType() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            parserService.parseSQL("SELECT 1", "unsupported_db");
+        });
+    }
+
+    @Test
+    void testParseWithInvalidSQL() {
+        String invalidSql = "SELEC * FORM users"; // 拼写错误
+        
+        assertThrows(IllegalArgumentException.class, () -> {
+            parserService.parseSQL(invalidSql, "mysql");
+        });
+    }
+
+    @Test
+    void testFormatSQL() {
+        String uglySql = "select id,name from users where age>18";
+        String formatted = parserService.formatSQL(uglySql, "mysql");
+
+        assertNotNull(formatted);
+        assertFalse(formatted.isEmpty());
+        assertTrue(formatted.contains("SELECT"));
+        assertTrue(formatted.contains("FROM"));
+        assertTrue(formatted.contains("WHERE"));
+    }
+
+    @Test
+    void testFormatSQLWithDifferentDialects() {
+        String sql = "select * from table1";
+        
+        String mysqlFormatted = parserService.formatSQL(sql, "mysql");
+        String hiveFormatted = parserService.formatSQL(sql, "hive");
+        String postgresFormatted = parserService.formatSQL(sql, "postgresql");
+        
+        assertNotNull(mysqlFormatted);
+        assertNotNull(hiveFormatted);
+        assertNotNull(postgresFormatted);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void testFormatWithBlankSQL(String sql) {
+        assertThrows(IllegalArgumentException.class, () -> {
+            parserService.formatSQL(sql, "mysql");
+        });
+    }
+
+    @Test
+    void testFormatWithInvalidSQL() {
+        String invalidSql = "SELEC * FORM users"; // 拼写错误
+        assertThrows(IllegalArgumentException.class, () -> {
+            parserService.formatSQL(invalidSql, "mysql");
+        });
+    }
+
+    @Test
+    void testParseWithCaseInsensitiveDbType() {
+        String sql = "SELECT 1";
+        
+        assertDoesNotThrow(() -> parserService.parseSQL(sql, "MySQL"));
+        assertDoesNotThrow(() -> parserService.parseSQL(sql, "HIVE"));
+        assertDoesNotThrow(() -> parserService.parseSQL(sql, "PostgreSQL"));
+    }
+}


### PR DESCRIPTION
## Changes
- ✅ Created DbTypeResolver class for database dialect resolution
- ✅ Created DruidParserService with parseSQL() and formatSQL() methods
- ✅ Support for MySQL, Hive, PostgreSQL, Oracle, SQLServer
- ✅ Unit tests with 81-100% coverage
- ✅ All 54 tests passing

## Verification
- [x] Unit tests pass
- [x] Code coverage > 80%
- [x] Linting passed
- [x] No conflicts with main branch

Closes #1