### PR TITLE
feat: implement Excel export API (Closes #15)

### DIFF
--- a/backend/src/main/java/com/lineage/controller/ExportController.java
+++ b/backend/src/main/java/com/lineage/controller/ExportController.java
@@ -1,0 +1,67 @@
+package com.lineage.controller;
+
+import com.lineage.core.tracker.LineageResult;
+import com.lineage.service.ExcelExportService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.io.ByteArrayOutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * 导出控制器
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/export")
+@Validated
+public class ExportController {
+    
+    @Autowired
+    private ExcelExportService excelExportService;
+    
+    /**
+     * 导出血缘分析结果为 Excel
+     *
+     * @param lineageResult 血缘分析结果
+     * @return Excel 文件流
+     */
+    @PostMapping("/excel")
+    public ResponseEntity<byte[]> exportExcel(@Valid @RequestBody LineageResult lineageResult) {
+        log.info("Received excel export request: {} dependencies", 
+                 lineageResult.getFieldDependencies().size());
+        
+        try {
+            // 生成 Excel 文件
+            ByteArrayOutputStream outputStream = excelExportService.exportToExcel(lineageResult);
+            byte[] bytes = outputStream.toByteArray();
+            
+            // 生成文件名
+            String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+            String filename = "lineage_analysis_" + timestamp + ".xlsx";
+            
+            // 设置响应头
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+            headers.setContentDispositionFormData("attachment", filename);
+            headers.setContentLength(bytes.length);
+            
+            log.info("Excel export successful: {} bytes, filename={}", bytes.length, filename);
+            
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .body(bytes);
+            
+        } catch (Exception e) {
+            log.error("Failed to export excel", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/backend/src/main/java/com/lineage/dto/excel/LineageExcelRow.java
+++ b/backend/src/main/java/com/lineage/dto/excel/LineageExcelRow.java
@@ -1,0 +1,40 @@
+package com.lineage.dto.excel;
+
+import com.alibaba.excel.annotation.ExcelProperty;
+import com.alibaba.excel.annotation.write.style.ColumnWidth;
+import com.alibaba.excel.annotation.write.style.HeadFontStyle;
+import com.alibaba.excel.annotation.write.style.HeadStyle;
+import lombok.Data;
+
+/**
+ * 血缘分析结果 Excel 行数据
+ */
+@Data
+@HeadStyle(fillForegroundColor = 22)
+@HeadFontStyle(bold = true, fontHeightInPoints = 11)
+public class LineageExcelRow {
+    
+    @ExcelProperty(value = "序号", index = 0)
+    @ColumnWidth(8)
+    private Integer index;
+    
+    @ExcelProperty(value = "目标字段", index = 1)
+    @ColumnWidth(20)
+    private String targetField;
+    
+    @ExcelProperty(value = "源表", index = 2)
+    @ColumnWidth(25)
+    private String sourceTable;
+    
+    @ExcelProperty(value = "源字段", index = 3)
+    @ColumnWidth(30)
+    private String sourceFields;
+    
+    @ExcelProperty(value = "转换逻辑", index = 4)
+    @ColumnWidth(40)
+    private String transformation;
+    
+    @ExcelProperty(value = "依赖层级", index = 5)
+    @ColumnWidth(12)
+    private Integer dependencyLevel;
+}

--- a/backend/src/main/java/com/lineage/service/ExcelExportService.java
+++ b/backend/src/main/java/com/lineage/service/ExcelExportService.java
@@ -1,0 +1,138 @@
+package com.lineage.service;
+
+import com.alibaba.excel.EasyExcel;
+import com.alibaba.excel.write.style.column.LongestMatchColumnWidthStyleStrategy;
+import com.lineage.core.tracker.FieldDependency;
+import com.lineage.core.tracker.LineageResult;
+import com.lineage.dto.excel.LineageExcelRow;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Excel 导出服务
+ */
+@Slf4j
+@Service
+public class ExcelExportService {
+    
+    /**
+     * 将血缘分析结果导出为 Excel
+     *
+     * @param lineageResult 血缘分析结果
+     * @return Excel 文件流
+     */
+    public ByteArrayOutputStream exportToExcel(LineageResult lineageResult) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        
+        try {
+            // 转换数据
+            List<LineageExcelRow> rows = convertToExcelRows(lineageResult);
+            
+            // 使用 EasyExcel 生成 Excel
+            EasyExcel.write(outputStream, LineageExcelRow.class)
+                    .registerWriteHandler(new LongestMatchColumnWidthStyleStrategy())
+                    .sheet("血缘分析结果")
+                    .doWrite(rows);
+            
+            log.info("Generated Excel with {} rows", rows.size());
+            
+        } catch (Exception e) {
+            log.error("Failed to generate Excel", e);
+            throw new RuntimeException("Excel generation failed", e);
+        }
+        
+        return outputStream;
+    }
+    
+    /**
+     * 转换 LineageResult 为 Excel 行数据
+     *
+     * @param lineageResult 血缘分析结果
+     * @return Excel 行数据列表
+     */
+    private List<LineageExcelRow> convertToExcelRows(LineageResult lineageResult) {
+        List<LineageExcelRow> rows = new ArrayList<>();
+        
+        if (lineageResult == null || lineageResult.getFieldDependencies() == null) {
+            return rows;
+        }
+        
+        int index = 1;
+        for (FieldDependency dep : lineageResult.getFieldDependencies()) {
+            LineageExcelRow row = new LineageExcelRow();
+            
+            // 序号
+            row.setIndex(index++);
+            
+            // 目标字段
+            String targetField = dep.getTargetAlias() != null && !dep.getTargetAlias().isEmpty() 
+                    ? dep.getTargetAlias() 
+                    : dep.getTargetField();
+            row.setTargetField(targetField);
+            
+            // 源表
+            String sourceTable = formatTableName(dep.getSourceTable(), dep.getSourceTableAlias());
+            row.setSourceTable(sourceTable);
+            
+            // 源字段
+            String sourceFields = dep.getSourceFields() != null && !dep.getSourceFields().isEmpty()
+                    ? String.join(", ", dep.getSourceFields())
+                    : "直接引用";
+            row.setSourceFields(sourceFields);
+            
+            // 转换逻辑
+            String transformation;
+            if (dep.getExpression() != null && !dep.getExpression().isEmpty()) {
+                transformation = dep.getExpression();
+            } else if (dep.isAggregation()) {
+                transformation = "聚合函数";
+            } else {
+                transformation = "直接映射";
+            }
+            row.setTransformation(transformation);
+            
+            // 依赖层级（简化计算）
+            int dependencyLevel = calculateDependencyLevel(dep);
+            row.setDependencyLevel(dependencyLevel);
+            
+            rows.add(row);
+        }
+        
+        return rows;
+    }
+    
+    /**
+     * 格式化表名
+     *
+     * @param table 表名
+     * @param alias 表别名
+     * @return 格式化后的表名
+     */
+    private String formatTableName(String table, String alias) {
+        if (table == null || table.isEmpty()) {
+            return "未知表";
+        }
+        if (alias != null && !alias.isEmpty() && !alias.equals(table)) {
+            return table + " (" + alias + ")";
+        }
+        return table;
+    }
+    
+    /**
+     * 计算依赖层级（简化版）
+     *
+     * @param dep 字段依赖
+     * @return 依赖层级
+     */
+    private int calculateDependencyLevel(FieldDependency dep) {
+        // 简化实现：有表达式或聚合为2层，否则为1层
+        if (dep.getExpression() != null || dep.isAggregation()) {
+            return 2;
+        }
+        return 1;
+    }
+}

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -25,10 +25,11 @@
 
     /**
      * 导出Excel
+     * @param {Object} lineageResult - 血缘分析结果
      * @returns {Promise} 导出结果
      */
-    static async exportExcel() {
-      const response = await axios.get(`${API_BASE_URL}/export/excel`, {
+    static async exportExcel(lineageResult) {
+      const response = await axios.post(`${API_BASE_URL}/export/excel`, lineageResult, {
         responseType: 'blob'
       });
       

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -3,6 +3,9 @@
 (function() {
   'use strict';
 
+  // 保存最近的分析结果
+  let currentLineageResult = null;
+
   // ============ 应用初始化 ============
   document.addEventListener('DOMContentLoaded', function() {
     initializeApp();
@@ -70,6 +73,9 @@
       // 调用API
       const result = await window.LineageAPI.analyze(sql, dbType.value);
       
+      // 保存分析结果
+      currentLineageResult = result;
+      
       // 显示结果
       displayResults(result);
       
@@ -92,15 +98,21 @@
     document.getElementById('sqlInput').value = '';
     document.getElementById('results').style.display = 'none';
     document.getElementById('exportBtn').disabled = true;
+    currentLineageResult = null;
   }
 
   /**
    * 处理导出操作
    */
   async function handleExport() {
+    if (!currentLineageResult) {
+      showMessage('请先分析SQL', 'warning');
+      return;
+    }
+
     try {
       showLoading(true);
-      await window.LineageAPI.exportExcel();
+      await window.LineageAPI.exportExcel(currentLineageResult);
       showMessage('导出成功', 'success');
     } catch (error) {
       console.error('导出失败:', error);


### PR DESCRIPTION
## 目标
实现 Excel 导出功能的后端接口，支持将血缘分析结果导出为 Excel 文件。

## 变更内容

### 后端
- ✅ 实现 /api/export/excel POST 接口
- ✅ 使用 EasyExcel 生成 Excel 文件
- ✅ 实现 ExcelExportService 数据转换服务
- ✅ 添加 LineageExcelRow DTO 定义列结构
- ✅ 包含表头：序号、目标字段、源表、源字段、转换逻辑、依赖层级
- ✅ 返回文件流（application/octet-stream）
- ✅ 文件命名：lineage_analysis_{timestamp}.xlsx

### 前端
- ✅ 修改 api.js exportExcel 为 POST 请求
- ✅ 在 main.js 中保存 currentLineageResult
- ✅ 导出时传递 lineageResult 参数
- ✅ 添加导出前的验证

## 验收标准
- [x] 实现 /api/export/excel 接口（POST）
- [x] 使用 EasyExcel 生成 Excel 文件
- [x] 包含表头：目标字段、源表、源字段、转换逻辑、依赖层级
- [x] 返回文件流
- [x] 文件命名格式正确

## 技术要点
- Maven 依赖：com.alibaba:easyexcel（已存在）
- 文件命名：lineage_analysis_{timestamp}.xlsx
- 处理中文编码和特殊字符
- POST 请求传递 LineageResult JSON

Closes #15