### PR TITLE
feat: implement Kettle batch upload (#36)

### DIFF
--- a/backend/src/main/java/com/lineage/kettle/controller/KettleController.java
+++ b/backend/src/main/java/com/lineage/kettle/controller/KettleController.java
@@ -1,15 +1,20 @@
 package com.lineage.kettle.controller;
 
+import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.lineage.dto.response.ApiResponse;
+import com.lineage.kettle.dto.BatchUploadResponse;
 import com.lineage.kettle.dto.KettleParseResponse;
+import com.lineage.kettle.entity.KettleFileRecord;
 import com.lineage.kettle.model.KettleSqlInfo;
 import com.lineage.kettle.model.KettleTransformation;
+import com.lineage.kettle.service.KettleFileService;
 import com.lineage.kettle.service.KettleService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.annotation.Resource;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -22,6 +27,9 @@ public class KettleController {
     
     @Resource
     private KettleService kettleService;
+    
+    @Resource
+    private KettleFileService kettleFileService;
     
     /**
      * 解析Kettle文件
@@ -96,5 +104,103 @@ public class KettleController {
             log.error("提取SQL失败", e);
             return ApiResponse.error(500, "提取失败: " + e.getMessage());
         }
+    }
+    
+    // ==================== 批量上传管理 ====================
+    
+    /**
+     * 上传单个Kettle文件（持久化）
+     */
+    @PostMapping("/upload")
+    public ApiResponse<BatchUploadResponse.FileUploadResult> uploadFile(@RequestParam("file") MultipartFile file) {
+        try {
+            log.info("上传Kettle文件: {}", file.getOriginalFilename());
+            
+            // 验证文件类型
+            String filename = file.getOriginalFilename();
+            if (filename == null || !filename.endsWith(".ktr")) {
+                return ApiResponse.error(400, "文件格式错误，仅支持.ktr文件");
+            }
+            
+            // 验证文件大小
+            if (file.getSize() > 50 * 1024 * 1024) {
+                return ApiResponse.error(400, "文件大小超过50MB限制");
+            }
+            
+            BatchUploadResponse.FileUploadResult result = kettleFileService.uploadFile(file);
+            
+            if ("success".equals(result.getStatus())) {
+                return ApiResponse.success("上传成功", result);
+            } else {
+                return ApiResponse.error(500, "上传失败: " + result.getErrorMessage());
+            }
+            
+        } catch (Exception e) {
+            log.error("上传文件失败", e);
+            return ApiResponse.error(500, "上传失败: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * 批量上传Kettle文件
+     */
+    @PostMapping("/batch-upload")
+    public ApiResponse<BatchUploadResponse> batchUpload(@RequestParam("files") MultipartFile[] files) {
+        try {
+            log.info("批量上传Kettle文件: count={}", files.length);
+            
+            if (files.length == 0) {
+                return ApiResponse.error(400, "未选择文件");
+            }
+            
+            // 验证文件类型
+            for (MultipartFile file : files) {
+                String filename = file.getOriginalFilename();
+                if (filename == null || !filename.endsWith(".ktr")) {
+                    return ApiResponse.error(400, "文件格式错误: " + filename);
+                }
+            }
+            
+            BatchUploadResponse response = kettleFileService.batchUpload(Arrays.asList(files));
+            return ApiResponse.success("批量上传完成", response);
+            
+        } catch (Exception e) {
+            log.error("批量上传失败", e);
+            return ApiResponse.error(500, "批量上传失败: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * 查询文件记录列表
+     */
+    @GetMapping("/files")
+    public ApiResponse<IPage<KettleFileRecord>> listFiles(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String status) {
+        IPage<KettleFileRecord> result = kettleFileService.listFileRecords(page, size, status);
+        return ApiResponse.success(result);
+    }
+    
+    /**
+     * 查询文件记录详情
+     */
+    @GetMapping("/files/{id}")
+    public ApiResponse<KettleFileRecord> getFileRecord(@PathVariable Long id) {
+        KettleFileRecord record = kettleFileService.getFileRecord(id);
+        if (record == null) {
+            return ApiResponse.error(404, "文件记录不存在");
+        }
+        return ApiResponse.success(record);
+    }
+    
+    /**
+     * 删除文件记录
+     */
+    @DeleteMapping("/files/{id}")
+    public ApiResponse<Void> deleteFileRecord(@PathVariable Long id) {
+        log.info("删除文件记录: id={}", id);
+        kettleFileService.deleteFileRecord(id);
+        return ApiResponse.success("删除成功", null);
     }
 }

--- a/backend/src/main/java/com/lineage/kettle/dto/BatchUploadResponse.java
+++ b/backend/src/main/java/com/lineage/kettle/dto/BatchUploadResponse.java
@@ -1,0 +1,50 @@
+package com.lineage.kettle.dto;
+
+import lombok.Data;
+import java.util.List;
+
+/**
+ * 批量上传响应
+ */
+@Data
+public class BatchUploadResponse {
+    
+    /**
+     * 任务ID
+     */
+    private String taskId;
+    
+    /**
+     * 总文件数
+     */
+    private int totalFiles;
+    
+    /**
+     * 成功数量
+     */
+    private int successCount;
+    
+    /**
+     * 失败数量
+     */
+    private int failedCount;
+    
+    /**
+     * 处理状态
+     */
+    private String status;
+    
+    /**
+     * 文件记录列表
+     */
+    private List<FileUploadResult> results;
+    
+    @Data
+    public static class FileUploadResult {
+        private String fileName;
+        private Long fileId;
+        private String status;
+        private String errorMessage;
+        private Integer sqlCount;
+    }
+}

--- a/backend/src/main/java/com/lineage/kettle/entity/KettleFileRecord.java
+++ b/backend/src/main/java/com/lineage/kettle/entity/KettleFileRecord.java
@@ -1,0 +1,84 @@
+package com.lineage.kettle.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+/**
+ * Kettle文件记录实体
+ */
+@Data
+@TableName("kettle_file_record")
+public class KettleFileRecord {
+    
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    
+    /**
+     * 文件名
+     */
+    private String fileName;
+    
+    /**
+     * 文件路径
+     */
+    private String filePath;
+    
+    /**
+     * 文件大小（字节）
+     */
+    private Long fileSize;
+    
+    /**
+     * 转换名称
+     */
+    private String transformationName;
+    
+    /**
+     * 转换描述
+     */
+    private String transformationDesc;
+    
+    /**
+     * 步骤数量
+     */
+    private Integer stepCount;
+    
+    /**
+     * SQL数量
+     */
+    private Integer sqlCount;
+    
+    /**
+     * 连接数量
+     */
+    private Integer hopCount;
+    
+    /**
+     * 解析状态（pending/success/failed）
+     */
+    private String parseStatus;
+    
+    /**
+     * 错误信息
+     */
+    private String errorMessage;
+    
+    /**
+     * 创建时间
+     */
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    
+    /**
+     * 更新时间
+     */
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+    
+    /**
+     * 逻辑删除
+     */
+    @TableLogic
+    private Integer isDeleted;
+}

--- a/backend/src/main/java/com/lineage/kettle/mapper/KettleFileRecordMapper.java
+++ b/backend/src/main/java/com/lineage/kettle/mapper/KettleFileRecordMapper.java
@@ -1,0 +1,12 @@
+package com.lineage.kettle.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.lineage.kettle.entity.KettleFileRecord;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * Kettle文件记录 Mapper
+ */
+@Mapper
+public interface KettleFileRecordMapper extends BaseMapper<KettleFileRecord> {
+}

--- a/backend/src/main/java/com/lineage/kettle/service/KettleFileService.java
+++ b/backend/src/main/java/com/lineage/kettle/service/KettleFileService.java
@@ -1,0 +1,194 @@
+package com.lineage.kettle.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.lineage.kettle.dto.BatchUploadResponse;
+import com.lineage.kettle.entity.KettleFileRecord;
+import com.lineage.kettle.mapper.KettleFileRecordMapper;
+import com.lineage.kettle.model.KettleSqlInfo;
+import com.lineage.kettle.model.KettleTransformation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.Resource;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Kettle文件管理服务
+ */
+@Slf4j
+@Service
+public class KettleFileService {
+    
+    @Resource
+    private KettleService kettleService;
+    
+    @Resource
+    private KettleFileRecordMapper kettleFileRecordMapper;
+    
+    @Value("${lineage.kettle.upload-dir:./uploads/kettle}")
+    private String uploadDir;
+    
+    /**
+     * 上传单个文件
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public BatchUploadResponse.FileUploadResult uploadFile(MultipartFile file) {
+        BatchUploadResponse.FileUploadResult result = new BatchUploadResponse.FileUploadResult();
+        result.setFileName(file.getOriginalFilename());
+        
+        try {
+            // 保存文件
+            File savedFile = saveFile(file);
+            
+            // 解析文件
+            KettleTransformation transformation = kettleService.parseKettleFile(savedFile);
+            List<KettleSqlInfo> sqls = kettleService.extractSqls(transformation);
+            
+            // 记录到数据库
+            KettleFileRecord record = new KettleFileRecord();
+            record.setFileName(file.getOriginalFilename());
+            record.setFilePath(savedFile.getAbsolutePath());
+            record.setFileSize(file.getSize());
+            record.setTransformationName(transformation.getName());
+            record.setTransformationDesc(transformation.getDescription());
+            record.setStepCount(transformation.getSteps().size());
+            record.setSqlCount(sqls.size());
+            record.setHopCount(transformation.getHops().size());
+            record.setParseStatus("success");
+            
+            kettleFileRecordMapper.insert(record);
+            
+            result.setFileId(record.getId());
+            result.setStatus("success");
+            result.setSqlCount(sqls.size());
+            
+            log.info("文件上传成功: fileName={}, sqlCount={}", file.getOriginalFilename(), sqls.size());
+            
+        } catch (Exception e) {
+            log.error("文件上传失败: fileName={}", file.getOriginalFilename(), e);
+            result.setStatus("failed");
+            result.setErrorMessage(e.getMessage());
+        }
+        
+        return result;
+    }
+    
+    /**
+     * 批量上传文件
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public BatchUploadResponse batchUpload(List<MultipartFile> files) {
+        String taskId = UUID.randomUUID().toString();
+        
+        log.info("批量上传开始: taskId={}, fileCount={}", taskId, files.size());
+        
+        BatchUploadResponse response = new BatchUploadResponse();
+        response.setTaskId(taskId);
+        response.setTotalFiles(files.size());
+        response.setStatus("completed");
+        
+        List<BatchUploadResponse.FileUploadResult> results = new ArrayList<>();
+        int successCount = 0;
+        int failedCount = 0;
+        
+        for (MultipartFile file : files) {
+            BatchUploadResponse.FileUploadResult result = uploadFile(file);
+            results.add(result);
+            
+            if ("success".equals(result.getStatus())) {
+                successCount++;
+            } else {
+                failedCount++;
+            }
+        }
+        
+        response.setResults(results);
+        response.setSuccessCount(successCount);
+        response.setFailedCount(failedCount);
+        
+        log.info("批量上传完成: taskId={}, success={}, failed={}", taskId, successCount, failedCount);
+        
+        return response;
+    }
+    
+    /**
+     * 保存上传的文件
+     */
+    private File saveFile(MultipartFile file) throws IOException {
+        // 确保上传目录存在
+        Path uploadPath = Paths.get(uploadDir);
+        if (!Files.exists(uploadPath)) {
+            Files.createDirectories(uploadPath);
+        }
+        
+        // 生成唯一文件名
+        String originalFilename = file.getOriginalFilename();
+        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        String newFilename = System.currentTimeMillis() + "_" + UUID.randomUUID().toString().substring(0, 8) + extension;
+        
+        // 保存文件
+        Path targetPath = uploadPath.resolve(newFilename);
+        file.transferTo(targetPath.toFile());
+        
+        log.info("文件保存成功: {}", targetPath);
+        
+        return targetPath.toFile();
+    }
+    
+    /**
+     * 查询文件记录列表
+     */
+    public IPage<KettleFileRecord> listFileRecords(int page, int size, String status) {
+        Page<KettleFileRecord> pageParam = new Page<>(page, size);
+        LambdaQueryWrapper<KettleFileRecord> wrapper = new LambdaQueryWrapper<>();
+        
+        if (status != null && !status.isEmpty()) {
+            wrapper.eq(KettleFileRecord::getParseStatus, status);
+        }
+        
+        wrapper.orderByDesc(KettleFileRecord::getCreateTime);
+        return kettleFileRecordMapper.selectPage(pageParam, wrapper);
+    }
+    
+    /**
+     * 获取文件记录详情
+     */
+    public KettleFileRecord getFileRecord(Long id) {
+        return kettleFileRecordMapper.selectById(id);
+    }
+    
+    /**
+     * 删除文件记录
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public void deleteFileRecord(Long id) {
+        KettleFileRecord record = kettleFileRecordMapper.selectById(id);
+        if (record != null) {
+            // 删除物理文件
+            try {
+                File file = new File(record.getFilePath());
+                if (file.exists()) {
+                    file.delete();
+                }
+            } catch (Exception e) {
+                log.warn("删除物理文件失败: {}", record.getFilePath(), e);
+            }
+            
+            // 删除数据库记录
+            kettleFileRecordMapper.deleteById(id);
+            log.info("删除文件记录成功: id={}", id);
+        }
+    }
+}

--- a/backend/src/main/resources/sql/schema.sql
+++ b/backend/src/main/resources/sql/schema.sql
@@ -50,3 +50,23 @@ CREATE TABLE IF NOT EXISTS column_metadata (
     KEY idx_table_id (table_id),
     KEY idx_column_name (column_name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='字段元数据表';
+
+-- Kettle文件记录表
+CREATE TABLE IF NOT EXISTS kettle_file_record (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '主键ID',
+    file_name VARCHAR(200) NOT NULL COMMENT '文件名',
+    file_path VARCHAR(500) NOT NULL COMMENT '文件路径',
+    file_size BIGINT COMMENT '文件大小（字节）',
+    transformation_name VARCHAR(200) COMMENT '转换名称',
+    transformation_desc VARCHAR(500) COMMENT '转换描述',
+    step_count INT DEFAULT 0 COMMENT '步骤数量',
+    sql_count INT DEFAULT 0 COMMENT 'SQL数量',
+    hop_count INT DEFAULT 0 COMMENT '连接数量',
+    parse_status VARCHAR(20) DEFAULT 'pending' COMMENT '解析状态（pending/success/failed）',
+    error_message TEXT COMMENT '错误信息',
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    update_time DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    is_deleted INT DEFAULT 0 COMMENT '逻辑删除（0-未删除，1-已删除）',
+    KEY idx_status (parse_status),
+    KEY idx_create_time (create_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Kettle文件记录表';

--- a/backend/src/test/java/com/lineage/kettle/service/KettleFileServiceTest.java
+++ b/backend/src/test/java/com/lineage/kettle/service/KettleFileServiceTest.java
@@ -1,0 +1,134 @@
+package com.lineage.kettle.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.lineage.kettle.dto.BatchUploadResponse;
+import com.lineage.kettle.entity.KettleFileRecord;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.Resource;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Kettle文件服务测试
+ */
+@SpringBootTest
+@Transactional
+class KettleFileServiceTest {
+    
+    @Resource
+    private KettleFileService kettleFileService;
+    
+    @Test
+    void testUploadFile() throws Exception {
+        // 加载测试文件
+        InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream("test-transformation.ktr");
+        assertNotNull(inputStream);
+        
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.ktr",
+                "text/xml",
+                inputStream
+        );
+        
+        // 上传文件
+        BatchUploadResponse.FileUploadResult result = kettleFileService.uploadFile(file);
+        
+        // 验证结果
+        assertNotNull(result);
+        assertEquals("success", result.getStatus());
+        assertNotNull(result.getFileId());
+        assertTrue(result.getSqlCount() > 0);
+    }
+    
+    @Test
+    void testBatchUpload() throws Exception {
+        // 加载测试文件
+        InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream("test-transformation.ktr");
+        assertNotNull(inputStream);
+        
+        MockMultipartFile file1 = new MockMultipartFile(
+                "files",
+                "test1.ktr",
+                "text/xml",
+                inputStream
+        );
+        
+        // 重新加载流
+        InputStream inputStream2 = getClass().getClassLoader()
+                .getResourceAsStream("test-transformation.ktr");
+        
+        MockMultipartFile file2 = new MockMultipartFile(
+                "files",
+                "test2.ktr",
+                "text/xml",
+                inputStream2
+        );
+        
+        List<MultipartFile> files = Arrays.asList(file1, file2);
+        
+        // 批量上传
+        BatchUploadResponse response = kettleFileService.batchUpload(files);
+        
+        // 验证结果
+        assertNotNull(response);
+        assertEquals(2, response.getTotalFiles());
+        assertTrue(response.getSuccessCount() > 0);
+        assertNotNull(response.getTaskId());
+        assertNotNull(response.getResults());
+    }
+    
+    @Test
+    void testListFileRecords() throws Exception {
+        // 上传测试文件
+        InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream("test-transformation.ktr");
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.ktr",
+                "text/xml",
+                inputStream
+        );
+        
+        kettleFileService.uploadFile(file);
+        
+        // 查询文件记录
+        IPage<KettleFileRecord> page = kettleFileService.listFileRecords(1, 10, null);
+        
+        assertNotNull(page);
+        assertTrue(page.getTotal() > 0);
+    }
+    
+    @Test
+    void testDeleteFileRecord() throws Exception {
+        // 上传测试文件
+        InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream("test-transformation.ktr");
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.ktr",
+                "text/xml",
+                inputStream
+        );
+        
+        BatchUploadResponse.FileUploadResult result = kettleFileService.uploadFile(file);
+        Long fileId = result.getFileId();
+        
+        // 删除文件记录
+        kettleFileService.deleteFileRecord(fileId);
+        
+        // 验证删除
+        KettleFileRecord deleted = kettleFileService.getFileRecord(fileId);
+        assertNull(deleted);
+    }
+}

--- a/frontend/kettle.html
+++ b/frontend/kettle.html
@@ -164,24 +164,57 @@
             </div>
             
             <div class="panel-body">
-                <!-- 文件上传区 -->
-                <div class="card">
-                    <div class="card-header">
-                        <h3>上传 Kettle 转换文件 (.ktr)</h3>
+                <!-- 标签页 -->
+                <div class="tabs" style="margin-bottom: 20px;">
+                    <button class="tab-btn active" data-tab="upload">文件上传</button>
+                    <button class="tab-btn" data-tab="history">上传历史</button>
+                </div>
+
+                <!-- 文件上传标签页 -->
+                <div id="upload-tab" class="tab-content active">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>上传 Kettle 转换文件 (.ktr)</h3>
+                        </div>
+                        
+                        <div class="upload-zone" id="upload-zone">
+                            <div class="upload-icon">📁</div>
+                            <h3>拖拽文件到这里或点击选择文件</h3>
+                            <p>支持 .ktr 文件，最大50MB，支持批量上传</p>
+                            <input type="file" id="file-input" class="file-input" accept=".ktr" multiple>
+                        </div>
+                        
+                        <div id="file-list" class="file-list"></div>
+                        
+                        <div class="button-group" style="margin-top: 16px;">
+                            <button id="parse-btn" class="btn btn-primary" disabled>解析文件</button>
+                            <button id="upload-save-btn" class="btn btn-success" disabled>上传并保存</button>
+                            <button id="clear-btn" class="btn btn-secondary">清空</button>
+                        </div>
                     </div>
-                    
-                    <div class="upload-zone" id="upload-zone">
-                        <div class="upload-icon">📁</div>
-                        <h3>拖拽文件到这里或点击选择文件</h3>
-                        <p>支持 .ktr 文件</p>
-                        <input type="file" id="file-input" class="file-input" accept=".ktr" multiple>
-                    </div>
-                    
-                    <div id="file-list" class="file-list"></div>
-                    
-                    <div class="button-group" style="margin-top: 16px;">
-                        <button id="parse-btn" class="btn btn-primary" disabled>解析文件</button>
-                        <button id="clear-btn" class="btn btn-secondary">清空</button>
+                </div>
+
+                <!-- 上传历史标签页 -->
+                <div id="history-tab" class="tab-content">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>上传历史</h3>
+                            <button class="btn btn-primary" onclick="loadFileHistory()">刷新</button>
+                        </div>
+                        <table class="data-table">
+                            <thead>
+                                <tr>
+                                    <th>文件名</th>
+                                    <th>转换名称</th>
+                                    <th>步骤数</th>
+                                    <th>SQL数</th>
+                                    <th>状态</th>
+                                    <th>上传时间</th>
+                                    <th>操作</th>
+                                </tr>
+                            </thead>
+                            <tbody id="history-list"></tbody>
+                        </table>
                     </div>
                 </div>
 


### PR DESCRIPTION
## 功能概述
实现 Kettle 文件批量上传和处理功能

## 实现内容

### 后端
- 创建 KettleFileRecord 实体和 Mapper
- 实现 KettleFileService 批量上传服务
- 新增 5 个 REST API:
  - POST /api/kettle/upload - 上传单个文件
  - POST /api/kettle/batch-upload - 批量上传
  - GET /api/kettle/files - 查询文件列表
  - GET /api/kettle/files/{id} - 查询文件详情
  - DELETE /api/kettle/files/{id} - 删除文件记录
- 新增数据库表 kettle_file_record
- 编写单元测试 (4 个测试用例)

### 前端
- kettle.html 新增标签页: 文件上传、上传历史
- kettle.js 实现:
  - 批量上传功能
  - 文件历史查看
  - 记录删除功能

## 测试
- [x] 单元测试通过
- [x] 单文件上传测试
- [x] 批量上传测试
- [x] 历史记录查询测试

## 相关 Issue
Closes #36

## 统计
- 后端代码: 474 行
- 前端代码: 206 行
- 测试代码: 134 行
- 总计: 814 行